### PR TITLE
Automatically dedupe deps after package-lock updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "extends": [
     "github>pagerinc/infra-renovate-config"
   ],
-  "pinVersions": false
+  "pinVersions": false,
+  "postUpdateOptions": [
+    "npmDedupe"
+  ]
 }


### PR DESCRIPTION
Docs: https://renovatebot.com/docs/configuration-options/#postupdateoptions

Proofs:
pagerinc/api-twilio#70

before changes in renovate config:
`git diff --stat package-lock.json`: 6 insertions(+), 24 deletions(-)
![Screen Shot 2019-08-21 at 12 31 33 PM](https://user-images.githubusercontent.com/4158258/63421857-fb3bd000-c411-11e9-9903-2078d97f25f5.png)

after:
`git diff --stat package-lock.json`: 9 insertions(+), 28 deletions(-)
and `npm dedupe` doesn't change lock file.
![Screen Shot 2019-08-21 at 12 49 24 PM](https://user-images.githubusercontent.com/4158258/63422162-8ae17e80-c412-11e9-9ee8-5bd61d04107a.png)

 
  