### PR TITLE
fix: remove deprecated option pinVersion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "github>pagerinc/infra-renovate-config"
   ],
-  "pinVersions": false,
   "postUpdateOptions": [
     "npmDedupe"
   ],


### PR DESCRIPTION
This PR will remove `pinVersion` and fix lockfile update and bring auto PRs for updates!