### PR TITLE
feat: auto update certain dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   "postUpdateOptions": [
     "npmDedupe"
   ],
-  "rangeStrategy": "update-lockfile"
+  "rangeStrategy": "update-lockfile",
+  "packageRules": [
+    {
+      "packagePatterns": ["^@types/"],
+      "groupName": "types",
+      "automerge": true
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,22 @@
   "rangeStrategy": "update-lockfile",
   "packageRules": [
     {
-      "packagePatterns": ["^@types/"],
-      "groupName": "types",
+      "description": "Auto update non-major Pager dependencies",
+      "packagePatterns": ["^@pager/"],
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "pager",
+      "automerge": true
+    },
+    {
+      "description": "Auto update non-major Hapi dependencies",
+      "packagePatterns": ["^@hapi/"],
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "hapi",
+      "automerge": true
+    },
+    {
+      "description": "Auto update dev dependencies",
+      "depTypeList": ["devDependencies"],
       "automerge": true
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -8,23 +8,35 @@
   "rangeStrategy": "update-lockfile",
   "packageRules": [
     {
+      "depTypeList": ["dependencies"],
+      "semanticCommitType": "build"
+    },
+    {
       "description": "Auto update non-major Pager dependencies",
       "packagePatterns": ["^@pager/"],
       "updateTypes": ["minor", "patch", "pin", "digest"],
-      "groupName": "pager",
+      "groupName": "pager (non-major)",
       "automerge": true
     },
     {
       "description": "Auto update non-major Hapi dependencies",
       "packagePatterns": ["^@hapi/"],
       "updateTypes": ["minor", "patch", "pin", "digest"],
-      "groupName": "hapi",
+      "groupName": "hapi (non-major)",
       "automerge": true
     },
     {
       "description": "Auto update dev dependencies",
       "depTypeList": ["devDependencies"],
+      "groupName": "devDependencies",
       "automerge": true
+    },
+    {
+      "description": "Auto update new relic",
+      "packagePatterns": ["newrelic"],
+      "groupName": "newrelic",
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }


### PR DESCRIPTION
This PR enables non-major auto update for:
- pager dependencies
- hapi dependencies

Enables auto update for:
- dev dependencies (types, eslint, sinon, mocha, etc.)
- new relic

See also https://github.com/pagerinc/infra-renovate-config/pull/10